### PR TITLE
Update to IntelliJ 2022.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,8 +15,9 @@ platformDownloadSources=true
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins=com.intellij.database
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
+# Java 17 is available since 2022.2
 javaVersion=11
-gradleVersion=7.2
+gradleVersion=7.5
 # Opt-out flag for bundling Kotlin standard library.
 # See https://kotlinlang.org/docs/reference/using-gradle.html#dependency-on-the-standard-library for details.
-kotlin.stdlib.default.dependency = false
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
This PR adds support for newly released IntelliJ IDEA 2022.2

Apparently, with this release, IntelliJ has moved to [Java 17 runtime](https://blog.jetbrains.com/idea/2022/05/intellij-idea-2022-2-eap-1/#JetBrains_Runtime) allowing for Java 17 as the compile target (tested locally). However, I kept version 11 so that the plugin is compatible with older IDEs as well.