### PR TITLE
Update plugin to support IntelliJ IDEA 2026.1+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = properties("pluginSinceBuild")
-            untilBuild = properties("pluginUntilBuild")
+            properties("pluginUntilBuild").takeIf { it.isNotEmpty() }?.let { untilBuild = it }
         }
     }
 
@@ -91,7 +91,7 @@ tasks {
     patchPluginXml {
         version = properties("pluginVersion")
         sinceBuild = properties("pluginSinceBuild")
-        untilBuild = properties("pluginUntilBuild")
+        properties("pluginUntilBuild").takeIf { it.isNotEmpty() }?.let { untilBuild = it }
 
         // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
         pluginDescription.set(

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,9 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=com.github.njuro.postgresvaultgithub
 pluginName=PostgreSQL Vault GitHub Auth
-pluginVersion=1.1.14
+pluginVersion=1.1.15
 pluginSinceBuild=261
-pluginUntilBuild=261.*
+pluginUntilBuild=
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
 pluginVerifierIdeVersions=261.22158.277


### PR DESCRIPTION
Update the plugin so it now supports IntelliJ IDEA 2025.3+ with no upper bound, making it compatible with 2026.1 and future releases.